### PR TITLE
feat(campaign): implement campaign details page and minimalist dashboard for home of engineers and companies

### DIFF
--- a/src/actions/dashboard/fetchCompanyDashboardData.ts
+++ b/src/actions/dashboard/fetchCompanyDashboardData.ts
@@ -1,0 +1,39 @@
+
+'use server';
+import db from '@/db';
+import { CommentWithAuthor } from '@/db/queries/comments';
+import { CampaignWithCompany, InvitationWithCampaignAndParties, ReportWithTags } from '@/types';
+
+export async function fetchCompanyDashboardData(userId: string) {
+  const user = await db.user.findUnique({ where: { id: userId }, include: { companies: true } });
+
+  const comments: CommentWithAuthor[] = await db.comment.findMany({
+    where: { userId },
+    take: 5,
+    orderBy: { createdAt: 'desc' },
+    include: { user: true, report: { include: { company: true } } },
+  });
+
+  const reports: ReportWithTags[] = await db.report.findMany({
+    where: { companyId: user?.companies?.[0]?.id },
+    take: 5,
+    orderBy: { createdAt: 'desc' },
+    include: { tags: true, user: true, StatusHistory: true, company: true, attachments: true, comments: true, campaign: true }
+  })
+
+  const campaigns: CampaignWithCompany[] = await db.campaign.findMany({
+    where: { userId },
+    take: 5,
+    orderBy: { createdAt: 'desc' },
+    include: { company: true },
+  });
+
+  const invitations: InvitationWithCampaignAndParties[] = await db.invitation.findMany({
+    where: { invitorId: userId },
+    take: 5,
+    orderBy: { createdAt: 'desc' },
+    include: { campaign: true, company: true, invitee: true, invitor: true },
+  });
+
+  return { comments, reports, campaigns, invitations };
+}

--- a/src/actions/dashboard/fetchEngineerDashboardData.ts
+++ b/src/actions/dashboard/fetchEngineerDashboardData.ts
@@ -1,0 +1,36 @@
+
+'use server';
+import db from '@/db';
+import { CommentWithAuthor } from '@/db/queries/comments';
+import { CampaignWithCompany, InvitationWithCampaignAndParties, ReportWithTags } from '@/types';
+export async function fetchEngineerDashboardData(userId: string) {
+  const comments: CommentWithAuthor[] = await db.comment.findMany({
+    where: { userId },
+    take: 5,
+    orderBy: { createdAt: 'desc' },
+    include: { user: true, report: { include: { company: true } } },
+  });
+
+  const reports: ReportWithTags[] = await db.report.findMany({
+    where: { userId },
+    take: 5,
+    orderBy: { createdAt: 'desc' },
+    include: { tags: true, user: true, StatusHistory: true, company: true, attachments: true, comments: true, campaign: true }
+  })
+
+  const campaigns: CampaignWithCompany[] = await db.campaign.findMany({
+    where: { userId },
+    take: 5,
+    orderBy: { createdAt: 'desc' },
+    include: { company: true },
+  });
+
+  const invitations: InvitationWithCampaignAndParties[] = await db.invitation.findMany({
+    where: { inviteeId: userId },
+    take: 5,
+    orderBy: { createdAt: 'desc' },
+    include: { campaign: true, company: true, invitee: true, invitor: true },
+  });
+
+  return { comments, reports, campaigns, invitations };
+}

--- a/src/actions/dashboard/index.ts
+++ b/src/actions/dashboard/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchEngineerDashboardData';
+export * from './fetchCompanyDashboardData';

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -4,3 +4,5 @@ export * from './users';
 export * from './companies';
 export * from './reports';
 export * from './attachments';
+export * from './dashboard';
+export * from './count';

--- a/src/app/@company/campaigns/[campaignId]/page.tsx
+++ b/src/app/@company/campaigns/[campaignId]/page.tsx
@@ -1,5 +1,6 @@
 import { fetchUser } from '@/actions';
 import db from '@/db';
+import { isPastDate } from '@/helpers/dates';
 import { CampaignWithInvitations, UserWithCompanies } from '@/types';
 import { CampaignStatus } from '@prisma/client';
 
@@ -36,9 +37,10 @@ export default async function ViewCampaign({
         ]}
         buttonProps={{
           primary:
-            campaign.status !== CampaignStatus.Archived
-              ? { text: 'Edit', href: `/campaigns/${campaignId}/edit` }
-              : undefined,
+            isPastDate(campaign.endDate) ||
+            campaign.status === CampaignStatus.Archived
+              ? undefined
+              : { text: 'Edit', href: `/campaigns/${campaignId}/edit` },
           secondary: { text: 'Back to campaigns', href: '/campaigns' },
         }}
       />

--- a/src/app/@company/campaigns/page.tsx
+++ b/src/app/@company/campaigns/page.tsx
@@ -25,6 +25,7 @@ export default async function Campaigns() {
     <div className="flex flex-col gap-4">
       <PageHeader crumbs={[{ href: '/campaigns', text: 'Campaigns' }]} />
       <CampaignsTable campaigns={campaigns} user={user} />
+      
     </div>
   );
 }

--- a/src/app/@company/contributors/page.tsx
+++ b/src/app/@company/contributors/page.tsx
@@ -5,14 +5,13 @@ import { Prisma, UserType } from '@prisma/client';
 
 import PageHeader from '@/components/common/page-header';
 import ContributorsTable from '@/components/contributors/contributors-table';
+import { ContributorWithReports } from '@/types';
 
 export const metadata: Metadata = {
   title: 'Contributors - Engineers raising the bar',
   description: 'Folks finding problems and fixing them',
 };
-export type ContributorWithReports = Prisma.UserGetPayload<{
-  include: { Report: true; attachments: true };
-}>;
+
 export default async function Contributors({ ...args }) {
   const contributors: ContributorWithReports[] = (await db.user.findMany({
     where: { userTypes: { has: UserType.ENGINEER } },

--- a/src/app/@company/page.tsx
+++ b/src/app/@company/page.tsx
@@ -1,20 +1,25 @@
-import { fetchUser } from '@/actions/users';
-import { auth } from '@/auth';
-import { Card, CardBody, CardHeader } from '@nextui-org/react';
+import {  fetchUser } from '@/actions';
+import { fetchCompanyDashboardData } from '@/actions/dashboard/fetchCompanyDashboardData';
+
+import PageHeader from '@/components/common/page-header';
+import Dashboard from '@/components/dashboard/company-dashboard';
 
 export default async function Home() {
   const user = await fetchUser();
+  if (!user) {
+    return <div>Not authorized</div>;
+  }
+  const { comments, reports, campaigns, invitations } =
+    await fetchCompanyDashboardData(user?.id);
   return (
     <div className="flex flex-col gap-4">
-      <h1>Home</h1>
-      <div className="flex flex-col gap-4 max-w-fit ">
-        <Card>
-          <CardHeader className="text-xl">{`${user?.email}`}</CardHeader>
-          <CardBody>
-            <p>{`This is the home of your companies ${user?.companies.map((c) => c.name).join(',')}`}</p>
-          </CardBody>
-        </Card>
-      </div>
+      <PageHeader crumbs={[{ href: '/reports', text: 'Reports' }]} />
+      <Dashboard
+        comments={comments}
+        reports={reports}
+        campaigns={campaigns}
+        invitations={invitations}
+      />
     </div>
   );
 }

--- a/src/app/@company/reports/page.tsx
+++ b/src/app/@company/reports/page.tsx
@@ -1,8 +1,8 @@
 import { fetchUser } from '@/actions';
 import { auth } from '@/auth';
 import db from '@/db';
-
 import { ReportWithTags } from '@/types';
+
 import PageHeader from '@/components/common/page-header';
 import ReportsTable from '@/components/reports/reports-table';
 
@@ -10,7 +10,15 @@ export default async function Reports() {
   const user = await fetchUser();
   const reports: ReportWithTags[] = await db.report.findMany({
     where: { companyId: { in: user?.companies.map((company) => company.id) } },
-    include: { company: true, tags: true, user: true, StatusHistory: true },
+    include: {
+      company: true,
+      tags: true,
+      user: true,
+      StatusHistory: true,
+      attachments: true,
+      campaign: true,
+      comments: true,
+    },
   });
 
   if (!user) {

--- a/src/app/@engineer/campaigns/[campaignId]/page.tsx
+++ b/src/app/@engineer/campaigns/[campaignId]/page.tsx
@@ -1,5 +1,7 @@
 import db from '@/db';
+import { CampaignWithCompany } from '@/types';
 
+import CampaignDetails from '@/components/campaigns/campaign-details';
 import PageHeader from '@/components/common/page-header';
 
 export default async function ViewCampaign({
@@ -7,11 +9,11 @@ export default async function ViewCampaign({
 }: {
   params: { campaignId: string };
 }) {
-  const campaign = await db.campaign.findFirst({
+  const campaign: CampaignWithCompany | null = await db.campaign.findFirst({
     where: {
       id: campaignId,
     },
-    include: { User: true },
+    include: { company: true },
   });
   return (
     <div className="flex flex-col gap-4">
@@ -21,7 +23,7 @@ export default async function ViewCampaign({
           { href: '/campaigns', text: `${campaign?.name}` },
         ]}
       />
-      <pre>{JSON.stringify(campaign, null, '\t')}</pre>
+      <CampaignDetails item={campaign} />
     </div>
   );
 }

--- a/src/app/@engineer/campaigns/page.tsx
+++ b/src/app/@engineer/campaigns/page.tsx
@@ -1,27 +1,19 @@
 import db from '@/db';
-import {
-  Button,
-  Card,
-  CardBody,
-  CardFooter,
-  Image,
-  Link,
-} from '@nextui-org/react';
+import { Campaign } from '@prisma/client';
 
-import { BreadCrumbsClient } from '@/components/breadcrumbs';
 import CampaignCard from '@/components/campaigns/campaign-card';
 import PageHeader from '@/components/common/page-header';
 
 export default async function Campaigns() {
-  const campaigns = await db.campaign.findMany();
+  const campaigns: Campaign[] | null = await db.campaign.findMany({
+    include: {},
+  });
 
   return (
     <div className="flex flex-col gap-4">
       <PageHeader crumbs={[{ href: '/campaigns', text: 'Campaigns' }]} />
       <div className="gap-2 grid grid-cols-2 sm:grid-cols-4">
-        {campaigns.map((item) => (
-          <CampaignCard key={item.id} item={item} />
-        ))}
+        {campaigns?.map((item) => <CampaignCard key={item.id} item={item} />)}
       </div>
     </div>
   );

--- a/src/app/@engineer/contributors/page.tsx
+++ b/src/app/@engineer/contributors/page.tsx
@@ -1,19 +1,17 @@
 import { Metadata } from 'next';
 
 import db from '@/db';
+import { getContributors } from '@/db/queries';
 import { Prisma, UserType } from '@prisma/client';
 
 import PageHeader from '@/components/common/page-header';
 import ContributorsTable from '@/components/contributors/contributors-table';
-import { getContributors } from '@/db/queries';
 
 export const metadata: Metadata = {
   title: 'Contributors - Engineers raising the bar',
   description: 'Folks finding problems and fixing them',
 };
-export type ContributorWithReports = Prisma.UserGetPayload<{
-  include: { Report: true };
-}>;
+
 export default async function Contributors({ ...args }) {
   const contributors = await getContributors();
   return (

--- a/src/app/@engineer/page.tsx
+++ b/src/app/@engineer/page.tsx
@@ -1,3 +1,24 @@
-export default function Home() {
-  return <h1>home of the engineers</h1>;
+import { fetchEngineerDashboardData, fetchUser } from '@/actions';
+
+import PageHeader from '@/components/common/page-header';
+import Dashboard from '@/components/dashboard/engineer-dashboard';
+
+export default async function Home() {
+  const user = await fetchUser();
+  if (!user) {
+    return <div>Not authorized</div>;
+  }
+  const { comments, reports, campaigns, invitations } =
+    await fetchEngineerDashboardData(user?.id);
+  return (
+    <div className="flex flex-col gap-4">
+      <PageHeader crumbs={[{ href: '/reports', text: 'Reports' }]} />
+      <Dashboard
+        comments={comments}
+        reports={reports}
+        campaigns={campaigns}
+        invitations={invitations}
+      />
+    </div>
+  );
 }

--- a/src/app/@engineer/reports/page.tsx
+++ b/src/app/@engineer/reports/page.tsx
@@ -1,8 +1,7 @@
 import { fetchUser } from '@/actions';
 import db from '@/db';
-import { UserWithCompanies } from '@/types';
+import { ReportWithTags, UserWithCompanies } from '@/types';
 
-import { ReportWithTags } from '@/types';
 import PageHeader from '@/components/common/page-header';
 import ReportsTable from '@/components/reports/reports-table';
 
@@ -10,7 +9,15 @@ export default async function Reports() {
   const user: UserWithCompanies | null = await fetchUser();
   const reports: ReportWithTags[] = await db.report.findMany({
     // where: { companyId: { in: user?.companies.map((company) => company.id) } },
-    include: { company: true, tags: true, user: true, StatusHistory: true , attachments: true, comments: true },
+    include: {
+      company: true,
+      tags: true,
+      user: true,
+      StatusHistory: true,
+      attachments: true,
+      comments: true,
+      campaign: true,
+    },
   });
 
   if (!user) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import NavTabs from '@/components/nav-tabs';
 import Providers from '@/app/providers';
 
 import NotFound from './not-found';
+import { UserWithCompanies } from '@/types';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -31,7 +32,7 @@ export default async function RootLayout({
   engineer: React.ReactNode;
 }) {
   const counts = await fetchAllCounts();
-  const user = await fetchUser();
+  const user :UserWithCompanies | null = await fetchUser();
 
   const rendered = () => {
     if (!user) {

--- a/src/components/_header.tsx
+++ b/src/components/_header.tsx
@@ -16,7 +16,7 @@ import ThemeSwitch from './common/theme-switch';
 
 // import SearchInput from './search-input';
 export default async function Header() {
-  const session = await auth();
+  // const session = await auth();
   return (
     <Navbar className="shadow mb-6">
       <NavbarBrand>
@@ -26,7 +26,7 @@ export default async function Header() {
       </NavbarBrand>
       <NavbarContent justify="center"></NavbarContent>
       <NavbarContent justify="end">
-        <HeaderAuth user={session?.user} />
+        {/* <HeaderAuth user={user} /> */}
         <ThemeSwitch />
       </NavbarContent>
     </Navbar>

--- a/src/components/campaigns/campaign-card.tsx
+++ b/src/components/campaigns/campaign-card.tsx
@@ -20,12 +20,15 @@ export default function CampaignCard({ item }: { item: CampaignWithCompany }) {
           width="100%"
           alt={item?.name}
           className="w-full object-cover h-[140px]"
-          src={`https://placehold.co/200x200?text=${item.name}`}
+          src={
+            item.company?.logo ||
+            `https://placehold.co/200x200?text=${item.name}`
+          }
         />
       </CardBody>
       <CardFooter className="text-small justify-between">
         <b>{item.name}</b>
-        <p className="text-default-500">{item.startDate?.toISOString()}</p>
+        <p className="text-default-500">{item.startDate?.toDateString()}</p>
       </CardFooter>
     </Card>
   );

--- a/src/components/campaigns/campaign-details.tsx
+++ b/src/components/campaigns/campaign-details.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { CampaignWithCompany } from '@/types';
+import {
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  Chip,
+  Image,
+} from '@nextui-org/react';
+
+import CampaignStatusChip from './campaign-status-chip';
+
+export default function CampaignDetails({
+  item,
+}: {
+  item: CampaignWithCompany | null;
+}) {
+  return (
+    <Card shadow="sm">
+      <CardHeader className="flex justify-center my-4">
+        <div className="flex flex-col items-center">
+          <b>{item?.name}</b>
+          <p className="text-default-500">
+            {item?.startDate?.toDateString()}-{item?.endDate?.toDateString()}
+          </p>
+          <p className="text-default-500">{item?.type}</p>
+        </div>
+        <div className="absolute bottom-2 md:top-2 right-4 m-4">
+          <CampaignStatusChip campaign={item} />
+        </div>
+      </CardHeader>
+      <CardBody className="overflow-visible p-10">
+        <Image
+          shadow="sm"
+          radius="lg"
+          width="100%"
+          alt={item?.name}
+          className="w-full object-cover h-[140px]"
+          src={`https://placehold.co/200x200/000000/FFFFFF?text=${item?.name}`}
+        />
+        <div className="flex flex-col gap-4 m-4">
+          <div className="flex gap-4">
+            <dt>Description:</dt>
+            <dd>{item?.description && <p>{item.description}</p>}</dd>
+          </div>
+          <div className="flex gap-4">
+            <dt>Rules:</dt>
+            <dd>{item?.rules && <p>{item.rules}</p>}</dd>
+          </div>
+        </div>
+      </CardBody>
+      <CardFooter className="flex text-small justify-center"></CardFooter>
+    </Card>
+  );
+}

--- a/src/components/campaigns/campaign-status-chip.tsx
+++ b/src/components/campaigns/campaign-status-chip.tsx
@@ -1,0 +1,45 @@
+import { pascalToSentenceCase } from '@/helpers';
+import { isPastDate } from '@/helpers/dates/isPastDate';
+import { CampaignWithCompany } from '@/types';
+import { Chip, ChipProps } from '@nextui-org/react';
+import { Campaign, CampaignStatus } from '@prisma/client';
+
+export default function CampaignStatusChip({
+  campaign,
+}: {
+  campaign: CampaignWithCompany | null;
+}) {
+  const statusColorMapping: Record<
+    CampaignStatus,
+    { color: ChipProps['color']; variant: ChipProps['variant'] }
+  > = {
+    [CampaignStatus.Created]: {
+      color: 'success',
+      variant: 'bordered',
+    },
+    [CampaignStatus.Archived]: {
+      color: 'default',
+      variant: 'bordered',
+    },
+  };
+  const isPastCampaign = isPastDate(campaign!.endDate);
+
+  const chipsProps: {
+    color: ChipProps['color'];
+    variant: ChipProps['variant'];
+  } = {
+    ...statusColorMapping[campaign!.status],
+    ...(isPastCampaign
+      ? {
+          color: 'danger',
+          variant: 'bordered',
+        }
+      : {}),
+  };
+  if (!campaign) return null;
+  return (
+    <Chip {...chipsProps} size="sm">
+      {isPastCampaign ? 'Ended' : pascalToSentenceCase(campaign.status)}
+    </Chip>
+  );
+}

--- a/src/components/campaigns/campaign-type-chip.tsx
+++ b/src/components/campaigns/campaign-type-chip.tsx
@@ -1,0 +1,15 @@
+import { pascalToSentenceCase } from '@/helpers';
+import { Chip, ChipProps } from '@nextui-org/react';
+import { CampaignType } from '@prisma/client';
+
+export default function CampaignTypeChip({ type }: { type: CampaignType }) {
+  const typeMapping: Record<CampaignType, ChipProps['color']> = {
+    [CampaignType.InvitationOnly]: 'warning',
+    [CampaignType.Public]: 'success',
+  };
+  return (
+    <Chip size="sm" variant='flat' color={typeMapping[type]}>
+      {pascalToSentenceCase(type)}
+    </Chip>
+  );
+}

--- a/src/components/campaigns/campaigns-table.tsx
+++ b/src/components/campaigns/campaigns-table.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
+import { CampaignWithInvitations } from '@/types';
 import {
   Button,
   Dropdown,
@@ -26,15 +27,16 @@ import { Campaign, User, UserType } from '@prisma/client';
 import { Key } from '@react-types/shared';
 
 import CampaignCard from './campaign-card';
+import CampaignStatusChip from './campaign-status-chip';
+import CampaignTypeChip from './campaign-type-chip';
 import { columns } from './columns';
-import { CampaignWithInvitations } from '@/types';
 
 const INITIAL_VISIBLE_COLUMNS = [
   'name',
   'startDate',
   'endDate',
   'type',
-  'company',
+  // 'company',
   'status',
 ];
 
@@ -112,7 +114,10 @@ export default function CampaignsTable({
   }, [sortDescriptor, items]);
 
   const renderCell = React.useCallback(
-    (campaign: CampaignWithInvitations, columnKey: keyof CampaignWithInvitations) => {
+    (
+      campaign: CampaignWithInvitations,
+      columnKey: keyof CampaignWithInvitations,
+    ) => {
       columnKey === 'status' && console.log('status', campaign.status);
       switch (columnKey) {
         case 'startDate':
@@ -124,6 +129,10 @@ export default function CampaignsTable({
           );
         case 'company':
           return <span>{String(campaign.company.name)}</span>;
+        case 'type':
+          return <CampaignTypeChip type={campaign.type} />;
+        case 'status':
+          return <CampaignStatusChip campaign={campaign} />;
         default:
           return <span>{String(campaign?.[columnKey])}</span>;
       }

--- a/src/components/campaigns/forms/create-campaign-form.tsx
+++ b/src/components/campaigns/forms/create-campaign-form.tsx
@@ -23,6 +23,8 @@ import { CampaignType, User } from '@prisma/client';
 import { useFormState } from 'react-dom';
 import { toast } from 'react-toastify';
 
+import CampaignTypeChip from '../campaign-type-chip';
+
 export const CreateCampaignForm = ({
   user,
   users,
@@ -58,7 +60,7 @@ export const CreateCampaignForm = ({
   return (
     <div>
       <form className="" id={FORM_ID} action={action}>
-        <div className="flex flex-col m-4 gap-4">
+        <div className="flex flex-col m-4">
           <div className="grid grid-cols-12">
             <div className="col-span-12 md:col-span-6">
               <div className="flex flex-col gap-4">
@@ -66,6 +68,9 @@ export const CreateCampaignForm = ({
                   label="Type"
                   name="type"
                   placeholder="Select a campaign type"
+                  renderValue={(selected) => (
+                    <CampaignTypeChip type={selected[0].key as CampaignType} />
+                  )}
                   onSelectionChange={(keys: Selection) => {
                     const selectedType = Array.from(keys)[0] as CampaignType;
                     setType(selectedType);
@@ -74,7 +79,7 @@ export const CreateCampaignForm = ({
                 >
                   {Object.values(CampaignType).map((type) => (
                     <SelectItem key={type} textValue={type}>
-                      <Chip>{type}</Chip>
+                      <CampaignTypeChip type={type} />
                     </SelectItem>
                   ))}
                 </Select>

--- a/src/components/campaigns/forms/view-campaign-form.tsx
+++ b/src/components/campaigns/forms/view-campaign-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CampaignWithCompany, UserWithCompanies } from '@/types';
+import { CampaignWithInvitations, UserWithCompanies } from '@/types';
 import { parseDate } from '@internationalized/date';
 import {
   Chip,
@@ -12,13 +12,10 @@ import {
 } from '@nextui-org/react';
 import { CampaignType } from '@prisma/client';
 
-import { InvitationWithUser } from '@/types/invitations';
-
 export const ViewCampaignForm = ({
   campaign,
-  user,
 }: {
-  campaign: CampaignWithCompany;
+  campaign: CampaignWithInvitations;
   user?: UserWithCompanies | null;
 }) => {
   return (
@@ -54,7 +51,9 @@ export const ViewCampaignForm = ({
                     selectionMode="multiple"
                     selectedKeys={
                       campaign.invitations.map(
-                        (invitation) => invitation.user?.id,
+                        (
+                          invitation: CampaignWithInvitations['invitations'][number],
+                        ) => invitation?.invitee?.id,
                       ) as string[]
                     }
                     multiple
@@ -62,12 +61,14 @@ export const ViewCampaignForm = ({
                   >
                     {/* Replace with actual users fetched from your DB */}
                     {campaign.invitations.map(
-                      (invitation: InvitationWithUser) => (
+                      (
+                        invitation: CampaignWithInvitations['invitations'][number],
+                      ) => (
                         <SelectItem
-                          key={`${invitation.user?.id.toString()}`}
-                          textValue={`${invitation.user?.name}`}
+                          key={`${invitation?.invitee?.id.toString()}`}
+                          textValue={`${invitation?.invitee?.name}`}
                         >
-                          <Chip>{invitation.user?.name}</Chip>
+                          <Chip>{invitation.invitee?.name}</Chip>
                         </SelectItem>
                       ),
                     )}

--- a/src/components/companies/company-badge.tsx
+++ b/src/components/companies/company-badge.tsx
@@ -1,0 +1,17 @@
+import { User } from '@nextui-org/react';
+import { Company } from '@prisma/client';
+
+export default function CompanyBadge({ company }: { company: Company }) {
+  return (
+    <User
+      avatarProps={{
+        radius: 'lg',
+        src: `${company?.logo}`,
+      }}
+      description={company.name}
+      name={company.name}
+    >
+      {company.name}
+    </User>
+  );
+}

--- a/src/components/contributors/contributor-card.tsx
+++ b/src/components/contributors/contributor-card.tsx
@@ -1,27 +1,33 @@
 import { ContributorWithReports } from '@/types';
 import {
-  Button,
   Card,
   CardBody,
   CardFooter,
   CardHeader,
   Link,
+  User,
 } from '@nextui-org/react';
 
 export default function ContributorCard({
   item,
 }: {
-  item: ContributorWithReports;
+  item: ContributorWithReports | null;
 }) {
   return (
-    <Card className="p-4" as={Link} href={`/contributors/${item.id}`}>
-      <CardHeader>{item.name}</CardHeader>
+    <Card className="p-4" as={Link} href={`/contributors/${item?.id}`}>
       <CardBody className="flex flex-col p-4 gap-4">
-        <pre>{JSON.stringify(item, null, '\t')}</pre>
+        <User
+          className="flex flex-col gap-4"
+          avatarProps={{ radius: 'lg', src: `${item?.image}` }}
+          name={item?.name}
+        />
+        <div className="flex justify-center">
+          {Boolean(item?.Report?.length && item?.Report?.length > 1)
+            ? item?.Report.length + ' Reports'
+            : item?.Report.length + ' Report'}{' '}
+        </div>
       </CardBody>
-      <CardFooter className="justify-end">
-        {/* <Button>Edit</Button> */}
-      </CardFooter>
+      <CardFooter className="justify-center">{`Reputation: ${item?.reputation}`}</CardFooter>
     </Card>
   );
 }

--- a/src/components/contributors/contributors-table.tsx
+++ b/src/components/contributors/contributors-table.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import { ContributorWithReports } from '@/types';
 import {
   Button,
   Dropdown,
@@ -24,12 +25,10 @@ import {
 } from '@nextui-org/react';
 import { Key } from '@react-types/shared';
 
-import { ContributorWithReports } from '@/types';
-
 import { columns } from '../contributors/data';
 import ContributorCard from './contributor-card';
 
-const INITIAL_VISIBLE_COLUMNS = ['name', 'reports', 'actions'];
+const INITIAL_VISIBLE_COLUMNS = ['name', 'reports', 'reputation'];
 
 export default function ContributorsTable({
   contributors,
@@ -116,10 +115,20 @@ export default function ContributorsTable({
               {contributor?.name}
             </User>
           );
+        case 'reputation':
+          return <span>{contributor?.reputation} </span>;
         case 'reports':
           return <span>{contributor?.Report?.length} </span>;
-        // default:
-        //   return <>{cellValue}</>;
+        default:
+          return (
+            <>
+              {typeof contributor?.[
+                columnKey as keyof ContributorWithReports
+              ] === 'string'
+                ? contributor?.[columnKey as keyof ContributorWithReports]
+                : '-'}
+            </>
+          );
       }
     },
     [],
@@ -311,7 +320,7 @@ export default function ContributorsTable({
       <div className="md:hidden flex flex-col gap-4 m-2">
         {topContent}
         {sortedItems.map((contributor) => (
-          <ContributorCard key={contributor.id} contributor={contributor} />
+          <ContributorCard key={contributor.id} item={contributor} />
         ))}
       </div>
     </div>

--- a/src/components/contributors/data.ts
+++ b/src/components/contributors/data.ts
@@ -4,6 +4,7 @@ const columns = [
   { name: "REPORTS", uid: "reports", sortable: true },
   { name: "CREATED AT", uid: "createdAt", sortable: true },
   { name: "UPDATED AT", uid: "updatedAt", sortable: true },
+  { name: "REPUTATION", uid: "reputation", sortable: true },
   { name: "ACTIONS", uid: "actions" },
 ];
 

--- a/src/components/dashboard/company-dashboard.tsx
+++ b/src/components/dashboard/company-dashboard.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { CommentWithAuthor } from '@/db/queries/comments';
+import {
+  CampaignWithCompany,
+  InvitationWithCampaignAndParties,
+  ReportWithTags,
+} from '@/types';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Divider,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+} from '@nextui-org/react';
+
+import { Category } from '../common/category';
+import { Status } from '../reports/status';
+
+export default function CompanyDashboard({
+  comments,
+  campaigns,
+  reports,
+  invitations,
+}: {
+  comments: CommentWithAuthor[];
+  campaigns: CampaignWithCompany[];
+  reports: ReportWithTags[];
+  invitations: InvitationWithCampaignAndParties[];
+}) {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col gap-4 m-4">
+      {/* Nested Card for Reports */}
+      <Card className="md:hidden p-2 shadow-lg">
+        <CardHeader className="justify-center">
+          <h4 className="text-xl font-semibold">Last 5 Reports</h4>
+        </CardHeader>
+        <CardBody className="text-center">
+          <div className="flex flex-col">
+            {reports.slice(0, 5).map((report, index) => (
+              <>
+                <Card
+                  key={report.id}
+                  className="flex flex-col items-center gap-4 m-2"
+                  isPressable
+                  onPress={() => router.push(`/reports/${report.id}`)}
+                >
+                  <CardBody className="flex flex-col text-center gap-4">
+                    <dl>
+                      <dd>
+                        <strong>{report.title}</strong>
+                      </dd>
+                    </dl>
+                    <dd>{report.campaign?.name}</dd>
+                    <div>
+                      <Category category={report.category} />
+                    </div>
+                    <dl>
+                      <dd>
+                        <Status status={report.status} />
+                      </dd>
+                    </dl>
+                  </CardBody>
+                </Card>
+                {index !== reports.length - 1 && <Divider className="m-4" />}
+              </>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Nested Card for Comments */}
+      <Card className="md:hidden p-2 shadow-lg">
+        <CardHeader className="justify-center">
+          <h4 className="text-xl font-semibold">Last 5 Comments</h4>
+        </CardHeader>
+        <CardBody className="text-center">
+          <div className="flex flex-col">
+            {comments.slice(0, 5).map((comment, index) => (
+              <>
+                <Card
+                  key={comment.id}
+                  className="flex flex-col items-center gap-4 m-2"
+                  isPressable
+                  onPress={() => router.push(`/reports/${comment.report?.id}`)}
+                >
+                  <CardBody className="flex flex-col text-center gap-4">
+                    <dl>
+                      <dd>
+                        <strong>{comment.report?.title}</strong>
+                      </dd>
+                    </dl>
+                    <p>{comment.content}</p>
+                  </CardBody>
+                </Card>
+                {index !== comments.length - 1 && <Divider className="m-4" />}
+              </>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Nested Card for Invitations */}
+      <Card className="md:hidden p-2 shadow-lg">
+        <CardHeader className="justify-center">
+          <h4 className="text-xl font-semibold">Last 5 Invitations</h4>
+        </CardHeader>
+        <CardBody className="text-center">
+          <div className="flex flex-col">
+            {invitations.slice(0, 5).map((invitation, index) => (
+              <>
+                <Card
+                  key={invitation.id}
+                  className="flex flex-col items-center gap-4 m-2"
+                  isPressable
+                  onPress={() =>
+                    router.push(`/campaigns/${invitation.campaign?.id}`)
+                  }
+                >
+                  <CardBody className="flex flex-col text-center gap-4">
+                    <dl>
+                      <dd>
+                        <strong>{invitation.campaign?.name}</strong>
+                      </dd>
+                    </dl>
+                  </CardBody>
+                </Card>
+                {index !== invitations.length - 1 && (
+                  <Divider className="m-4" />
+                )}
+              </>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Nested Card for Campaigns */}
+      <Card className="md:hidden p-2 shadow-lg">
+        <CardHeader className="justify-center">
+          <h4 className="text-xl font-semibold">Last 5 Campaigns</h4>
+        </CardHeader>
+        <CardBody className="text-center">
+          <div className="flex flex-col">
+            {campaigns.slice(0, 5).map((campaign, index) => (
+              <>
+                <Card
+                  key={campaign.id}
+                  className="flex flex-col items-center gap-4 m-2"
+                  isPressable
+                  onPress={() => router.push(`/campaigns/${campaign.id}`)}
+                >
+                  <CardBody className="flex flex-col text-center gap-4">
+                    <dl>
+                      <dd>
+                        <strong>{campaign.name}</strong>
+                      </dd>
+                    </dl>
+                  </CardBody>
+                </Card>
+                {index !== campaigns.length - 1 && <Divider className="m-4" />}
+              </>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Row 1: Reports and Comments */}
+      <div className="hidden md:flex md:flex-wrap gap-4">
+        {/* Reports Table */}
+        <div className="flex-1 min-w-[45%]">
+          <div className="m-4">
+            <h2>Last 5 Reports on Your Campaigns</h2>
+          </div>
+          <Table
+            className="hidden md:flex"
+            aria-label="Reports table"
+            isStriped
+            topContentPlacement="outside"
+          >
+            <TableHeader
+              columns={[
+                { uid: 'title', name: 'Title' },
+                { uid: 'campaign', name: 'Campaign' },
+                { uid: 'category', name: 'Category' },
+                { uid: 'status', name: 'Status' },
+              ]}
+            >
+              {(column) => (
+                <TableColumn key={column.uid}>{column.name}</TableColumn>
+              )}
+            </TableHeader>
+
+            <TableBody emptyContent={'No report found'}>
+              {reports.map((report) => (
+                <TableRow key={report.id}>
+                  <TableCell>{report.title}</TableCell>
+                  <TableCell>{report.campaign?.name}</TableCell>
+                  <TableCell>
+                    <Category category={report.category} />
+                  </TableCell>
+                  <TableCell>
+                    <Status status={report.status} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Comments Table */}
+        <div className="flex-1 min-w-[45%]">
+          <div className="m-4">
+            <h2>Last 5 Comments on Your Reports</h2>
+          </div>
+          <Table
+            className="hidden md:flex"
+            aria-label="Comments table"
+            isStriped
+            topContentPlacement="outside"
+          >
+            <TableHeader
+              columns={[
+                { uid: 'report', name: 'Report' },
+                { uid: 'comment', name: 'Comment' },
+              ]}
+            >
+              {(column) => (
+                <TableColumn key={column.uid}>{column.name}</TableColumn>
+              )}
+            </TableHeader>
+
+            <TableBody emptyContent={'No comment found'}>
+              {comments.map((comment) => (
+                <TableRow key={comment.id}>
+                  <TableCell>{comment.report?.title}</TableCell>
+                  <TableCell>{comment.content}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+
+      {/* Row 2: Invitations and Campaigns */}
+      <div className="hidden md:flex md:flex-wrap gap-4">
+        {/* Invitations Table */}
+        <div className="flex-1 min-w-[45%]">
+          <div className="m-4">
+            <h2>Last 5 Invitations Sent by Your Company</h2>
+          </div>
+          <Table
+            className="hidden md:flex"
+            aria-label="Invitations table"
+            isStriped
+            topContentPlacement="outside"
+          >
+            <TableHeader
+              columns={[
+                { uid: 'campaign', name: 'Campaign' },
+                { uid: 'invitee', name: 'Invitee' },
+              ]}
+            >
+              {(column) => (
+                <TableColumn key={column.uid}>{column.name}</TableColumn>
+              )}
+            </TableHeader>
+
+            <TableBody emptyContent={'No invitation found'}>
+              {invitations.map((invitation) => (
+                <TableRow key={invitation.id}>
+                  <TableCell>{invitation.campaign?.name}</TableCell>
+                  <TableCell>{invitation.invitee?.name}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Campaigns Table */}
+        <div className="flex-1 min-w-[45%]">
+          <div className="m-4">
+            <h2>Last 5 Campaigns Created by Your Company</h2>
+          </div>
+          <Table
+            className="hidden md:flex"
+            aria-label="Campaigns table"
+            isStriped
+            topContentPlacement="outside"
+          >
+            <TableHeader
+              columns={[
+                { uid: 'campaign', name: 'Campaign' },
+                { uid: 'description', name: 'Description' },
+              ]}
+            >
+              {(column) => (
+                <TableColumn key={column.uid}>{column.name}</TableColumn>
+              )}
+            </TableHeader>
+
+            <TableBody emptyContent={'No campaign found'}>
+              {campaigns.map((campaign) => (
+                <TableRow key={campaign.id}>
+                  <TableCell>{campaign.name}</TableCell>
+                  <TableCell>{campaign.description}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/engineer-dashboard.tsx
+++ b/src/components/dashboard/engineer-dashboard.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { CommentWithAuthor } from '@/db/queries/comments';
+import {
+  CampaignWithCompany,
+  InvitationWithCampaignAndParties,
+  ReportWithTags,
+} from '@/types';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Divider,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+} from '@nextui-org/react';
+
+import { Category } from '../common/category';
+import { Status } from '../reports/status';
+
+export default function Dashboard({
+  comments,
+  campaigns,
+  reports,
+  invitations,
+}: {
+  comments: CommentWithAuthor[];
+  campaigns: CampaignWithCompany[];
+  reports: ReportWithTags[];
+  invitations: InvitationWithCampaignAndParties[];
+}) {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col gap-4 m-4">
+      {/* Nested Card for Reports */}
+      <Card className="md:hidden p-2 shadow-lg">
+        <CardHeader className="justify-center">
+          <h4 className="text-xl font-semibold">Last 5 Reports</h4>
+        </CardHeader>
+        <CardBody className="text-center">
+          <div className="flex flex-col">
+            {reports.slice(0, 5).map((report, index) => (
+              <>
+                <Card
+                  key={report.id}
+                  className="flex flex-col items-center gap-4 m-2"
+                  isPressable
+                  onPress={() => router.push(`/reports/${report.id}`)}
+                >
+                  <CardBody className="flex flex-col text-center gap-4">
+                    <dl>
+                      <dd>
+                        <strong>{report.title}</strong>
+                      </dd>
+                    </dl>
+                    <dd>{report.company?.name}</dd>
+                    <div>
+                      <Category category={report.category} />
+                    </div>
+                    <dl>
+                      <dd>
+                        <Status status={report.status} />
+                      </dd>
+                    </dl>
+                  </CardBody>
+                </Card>
+                {index !== reports.length - 1 && <Divider className="m-4" />}
+              </>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Nested Card for Comments */}
+      <Card className="md:hidden p-2 shadow-lg">
+        <CardHeader className="justify-center">
+          <h4 className="text-xl font-semibold">Last 5 Comments</h4>
+        </CardHeader>
+        <CardBody className="text-center">
+          <div className="flex flex-col">
+            {comments.slice(0, 5).map((comment, index) => (
+              <>
+                <Card
+                  key={comment.id}
+                  className="flex flex-col items-center gap-4 m-2"
+                  isPressable
+                  onPress={() => router.push(`/reports/${comment.report.id}`)}
+                >
+                  <CardBody className="flex flex-col text-center gap-4">
+                    <dl>
+                      <dd>
+                        <strong>{comment.report.title}</strong>
+                      </dd>
+                    </dl>
+                    <dd>{comment.report.company?.name}</dd>
+                    <p>{comment.content}</p>
+                  </CardBody>
+                </Card>
+                {index !== comments.length - 1 && <Divider className="m-4" />}
+              </>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Nested Card for Invitations */}
+      <Card className="md:hidden p-2 shadow-lg">
+        <CardHeader className="justify-center">
+          <h4 className="text-xl font-semibold">Last 5 Invitations</h4>
+        </CardHeader>
+        <CardBody className="text-center">
+          <div className="flex flex-col">
+            {invitations.slice(0, 5).map((invitation, index) => (
+              <>
+                <Card
+                  key={invitation.id}
+                  className="flex flex-col items-center gap-4 m-2"
+                  isPressable
+                  onPress={() =>
+                    router.push(`/campaigns/${invitation.campaign.id}`)
+                  }
+                >
+                  <CardBody className="flex flex-col text-center gap-4">
+                    <dl>
+                      <dd>
+                        <strong>{invitation.campaign.name}</strong>
+                      </dd>
+                    </dl>
+                    <dd>{invitation.company.name}</dd>
+                  </CardBody>
+                </Card>
+                {index !== invitations.length - 1 && (
+                  <Divider className="m-4" />
+                )}
+              </>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Nested Card for Campaigns */}
+      <Card className="md:hidden p-2 shadow-lg">
+        <CardHeader className="justify-center">
+          <h4 className="text-xl font-semibold">Last 5 Campaigns</h4>
+        </CardHeader>
+        <CardBody className="text-center">
+          <div className="flex flex-col">
+            {campaigns.slice(0, 5).map((campaign, index) => (
+              <>
+                <Card
+                  key={campaign.id}
+                  className="flex flex-col items-center gap-4 m-2"
+                  isPressable
+                  onPress={() => router.push(`/campaigns/${campaign.id}`)}
+                >
+                  <CardBody className="flex flex-col text-center gap-4">
+                    <dl>
+                      <dd>
+                        <strong>{campaign.name}</strong>
+                      </dd>
+                    </dl>
+                    <dd>{campaign.company.name}</dd>
+                  </CardBody>
+                </Card>
+                {index !== campaigns.length - 1 && <Divider className="m-4" />}
+              </>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+      {/* Row 1: Reports and Comments */}
+      <div className="hidden md:flex md:flex-wrap gap-4 ">
+        {/* Reports Table */}
+        <div className="flex-1 min-w-[45%]">
+          <div className="m-4">
+            <h2>Last 5 Reports</h2>
+          </div>
+          <Table
+            className="hidden md:flex"
+            aria-label="Reports table"
+            isStriped
+            topContentPlacement="outside"
+          >
+            <TableHeader
+              columns={[
+                { uid: 'title', name: 'Title' },
+                { uid: 'company', name: 'Company' },
+                { uid: 'category', name: 'Category' },
+                { uid: 'status', name: 'Status' },
+              ]}
+            >
+              {(column) => (
+                <TableColumn key={column.uid}>{column.name}</TableColumn>
+              )}
+            </TableHeader>
+
+            <TableBody emptyContent={'No report found'}>
+              {reports.map((report) => (
+                <TableRow key={report.id}>
+                  <TableCell>{report.title}</TableCell>
+                  <TableCell>{report.company?.name}</TableCell>
+                  <TableCell>
+                    <Category category={report.category} />
+                  </TableCell>
+                  <TableCell>
+                    <Status status={report.status} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Comments Table */}
+        <div className="flex-1 min-w-[45%]">
+          <div className="m-4">
+            <h2>Last 5 Comments</h2>
+          </div>
+          <Table
+            className="hidden md:flex"
+            aria-label="Comments table"
+            isStriped
+            topContentPlacement="outside"
+          >
+            <TableHeader
+              columns={[
+                { uid: 'report', name: 'Report' },
+                { uid: 'company', name: 'Company' },
+                { uid: 'comment', name: 'Comment' },
+              ]}
+            >
+              {(column) => (
+                <TableColumn key={column.uid}>{column.name}</TableColumn>
+              )}
+            </TableHeader>
+
+            <TableBody emptyContent={'No comment found'}>
+              {comments.map((comment) => (
+                <TableRow key={comment.id}>
+                  <TableCell>{comment.report.title}</TableCell>
+                  <TableCell>{comment?.report?.company?.name}</TableCell>
+                  <TableCell>{comment.content}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+
+      {/* Row 2: Invitations and Campaigns */}
+      <div className="hidden md:flex md:flex-wrap gap-4 ">
+        {/* Invitations Table */}
+        <div className="flex-1 min-w-[45%]">
+          <div className="m-4">
+            <h2>Last 5 Invitations</h2>
+          </div>
+          <Table
+            className="hidden md:flex"
+            aria-label="Invitations table"
+            isStriped
+            topContentPlacement="outside"
+          >
+            <TableHeader
+              columns={[
+                { uid: 'campaign', name: 'Campaign' },
+                { uid: 'company', name: 'Company' },
+              ]}
+            >
+              {(column) => (
+                <TableColumn key={column.uid}>{column.name}</TableColumn>
+              )}
+            </TableHeader>
+
+            <TableBody emptyContent={'No invitation found'}>
+              {invitations.map((invitation) => (
+                <TableRow key={invitation.id}>
+                  <TableCell>{invitation.campaign.name}</TableCell>
+                  <TableCell>{invitation.company.name}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Campaigns Table */}
+        <div className="flex-1 min-w-[45%]">
+          <div className="m-4">
+            <h2>Last 5 Campaigns</h2>
+          </div>
+          <Table
+            className="hidden md:flex"
+            aria-label="Campaigns table"
+            isStriped
+            topContentPlacement="outside"
+          >
+            <TableHeader
+              columns={[
+                { uid: 'campaign', name: 'Campaign' },
+                { uid: 'company', name: 'Company' },
+              ]}
+            >
+              {(column) => (
+                <TableColumn key={column.uid}>{column.name}</TableColumn>
+              )}
+            </TableHeader>
+
+            <TableBody emptyContent={'No campaign found'}>
+              {campaigns.map((campaign) => (
+                <TableRow key={campaign.id}>
+                  <TableCell>{campaign.name}</TableCell>
+                  <TableCell>{campaign.company.name}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,0 +1,1 @@
+export * from './engineer-dashboard';

--- a/src/components/header-auth.tsx
+++ b/src/components/header-auth.tsx
@@ -1,4 +1,5 @@
 import * as actions from '@/actions';
+import { UserWithCompanies } from '@/types';
 import {
   Button,
   Link,
@@ -11,10 +12,15 @@ import { Session } from 'next-auth';
 
 import SignInAuth0Button from './common/sign-in-auth0-button';
 import SignInGitHubButton from './common/sign-in-github-button';
+import { isCompany } from '@/helpers';
 
 // import { useSession } from 'next-auth/react';
 
-export default function HeaderAuth({ user }: { user: Session['user'] | null }) {
+export default function HeaderAuth({
+  user,
+}: {
+  user: UserWithCompanies | null;
+}) {
   let authContent: React.ReactNode;
   if (!user) {
     authContent = (
@@ -30,14 +36,17 @@ export default function HeaderAuth({ user }: { user: Session['user'] | null }) {
     authContent = (
       <Popover placement="bottom">
         <PopoverTrigger>
-            <User
-              className="cursor-pointer"
-              avatarProps={{ radius: 'lg', src: `${user?.image}` }}
-              description={<span className="">{user.email}</span>}
-              name={user?.name}
-            >
-              {user?.name}
-            </User>
+          <User
+            // break-words max-w-[174px]
+            className="cursor-pointer"
+            avatarProps={{ radius: 'lg', src: `${user?.image}` }}
+            description={
+              <span className="break-words max-w-[10px]">{user.email}</span>
+            }
+            name={isCompany(user) ? user?.companies?.[0]?.name : user?.name}
+          >
+            {user?.name}
+          </User>
         </PopoverTrigger>
         <PopoverContent>
           <div className="flex flex-col gap-4 p-4">

--- a/src/components/nav-tabs.tsx
+++ b/src/components/nav-tabs.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import React from 'react';
+import React, { FC } from 'react';
 
 import { usePathname } from 'next/navigation';
 
 import { signIn, signInAuth0, signOut } from '@/actions';
+import { isCompany } from '@/helpers';
+import { UserWithCompanies } from '@/types';
 import {
   Avatar,
   Button,
@@ -22,7 +24,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@nextui-org/react';
-import { User } from 'next-auth';
+import { IconProps } from 'react-toastify';
 
 import Icon from './common/Icon';
 import SignInAuth0Button from './common/sign-in-auth0-button';
@@ -41,7 +43,7 @@ export default function NavTabs({
   user,
   count,
 }: {
-  user: User | null;
+  user: UserWithCompanies | null;
   count: Count;
 }) {
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
@@ -74,6 +76,13 @@ export default function NavTabs({
         color?: LinkProps['color'] | undefined;
       }[];
 
+  type NavItem = {
+    emoji: string | React.ReactNode;
+    label: string;
+    href: string;
+    count?: number;
+  };
+
   const navItems = [
     {
       emoji: <Icon name="bug" />,
@@ -89,13 +98,15 @@ export default function NavTabs({
       href: '/contributors',
       count: count.contributors,
     },
-    {
-      emoji: <Icon name="buildings" />,
-      // emoji: '🏢',
-      label: 'Companies',
-      href: '/companies',
-      count: count.companies,
-    },
+    isCompany(user!)
+      ? null
+      : {
+          emoji: <Icon name="buildings" />,
+          // emoji: '🏢',
+          label: 'Companies',
+          href: '/companies',
+          count: count.companies,
+        },
     {
       emoji: (
         <div className="flex">
@@ -119,7 +130,7 @@ export default function NavTabs({
       label: 'Leaderboard',
       href: '/leaderboard',
     },
-  ];
+  ].filter(Boolean) as NavItem[];
   const noop = () => {};
 
   return (
@@ -184,7 +195,7 @@ export default function NavTabs({
         ))}
       </NavbarContent>
 
-      <NavbarContent className="md:p-10 flex flex-row-reverse justify-between">
+      <NavbarContent className="flex flex-row-reverse justify-between">
         <NavbarItem className="xl:hidden">
           <Popover>
             <PopoverTrigger>
@@ -195,9 +206,19 @@ export default function NavTabs({
                 {user ? (
                   <div className="flex flex-col items-center gap-4 p-4 xs:hidden">
                     <span>{user?.email}</span>
-                    <Button as={Link} href={`/profile/${user.id}}`} startContent={<Icon name="user" />}>Profile</Button>
+                    <Button
+                      as={Link}
+                      href={`/profile/${user.id}}`}
+                      startContent={<Icon name="user" />}
+                    >
+                      Profile
+                    </Button>
                     <form action={signOut}>
-                      <Button color="danger" type="submit" startContent={<Icon name="log-out" />}>
+                      <Button
+                        color="danger"
+                        type="submit"
+                        startContent={<Icon name="log-out" />}
+                      >
                         Logout
                       </Button>
                     </form>

--- a/src/components/reports/tag.tsx
+++ b/src/components/reports/tag.tsx
@@ -2,9 +2,47 @@ import { pascalToSentenceCase } from '@/helpers/strings/pascalToSentenceCase';
 import { Chip } from '@nextui-org/react';
 import { Tag } from '@prisma/client';
 
+import Icon from '../common/Icon';
+
+const tagsIconMapping = (tags: Tag) => {
+  switch (tags.name) {
+    case 'Visual Problem':
+      return 'low-vision';
+    case 'Accessibility (a11y) Issue':
+      return 'accessibility';
+    case 'Data Issue':
+      return 'data';
+    case 'Performance Issue':
+      return 'run';
+    case 'Security Vulnerability':
+      return 'lock';
+    case 'Functional Bug':
+      return 'bug-alt';
+    case 'Usability Issue':
+      return 'block';
+    case 'Compatibility Issue':
+      return 'extension';
+    case 'Content Issue':
+      return 'book-content';
+    case 'Code Issue':
+      return 'code-alt';
+    case 'Integration Issue':
+      return 'transfer';
+    case 'Responsive Design Issue':
+      return 'devices';
+    default:
+      return '';
+  }
+};
 export const TagChip = ({ tag }: { tag: Tag }) => {
   return (
-    <Chip className="capitalize" size="sm" color='primary'>
+    <Chip
+      className="capitalize"
+      size="sm"
+      variant='solid'
+      color="primary"
+      startContent={<Icon name={tagsIconMapping(tag)} size="medium" />}
+    >
       {`${pascalToSentenceCase(tag.name)}`}
     </Chip>
   );

--- a/src/db/queries/comments.ts
+++ b/src/db/queries/comments.ts
@@ -2,7 +2,7 @@ import { Prisma, } from '@prisma/client';
 import db from "@/db";
 import { cache } from "react";
 
-export type CommentWithAuthor = Prisma.CommentGetPayload<{ include: { user: true } }>;
+export type CommentWithAuthor = Prisma.CommentGetPayload<{ include: { user: true, report: { include: { company: true } } } }>;
 
 
 
@@ -10,7 +10,10 @@ export const fetchCommentsByReportId = cache((reportId: string): Promise<Comment
   return db.comment.findMany({
     where: { reportId },
     include: {
-      user: true
+      user: true,
+      report: {
+        include: { company: true }
+      }
     }
   })
 });

--- a/src/helpers/dates/index.ts
+++ b/src/helpers/dates/index.ts
@@ -1,0 +1,1 @@
+export * from './isPastDate';

--- a/src/helpers/dates/isPastDate.ts
+++ b/src/helpers/dates/isPastDate.ts
@@ -1,0 +1,10 @@
+export const isPastDate = (date: Date) => {
+  const today = new Date();
+  
+  // Strip the time portion of both dates
+  const currentDate = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const inputDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  
+  // Return true if the input date is before or equal to today
+  return inputDate < currentDate;
+};

--- a/src/helpers/users/index.ts
+++ b/src/helpers/users/index.ts
@@ -1,7 +1,8 @@
+import { UserWithCompanies } from "@/types";
 import { User, UserType } from "@prisma/client";
 
 export const isUser = (type: UserType, user: User) => { return user.userTypes.includes(type) }
-export const isEngineer = (user: User) => { return user.userTypes.includes(UserType.ENGINEER) }
-export const isCompany = (user: User) => { return user.userTypes.includes(UserType.COMPANY) }
-export const isAdmin = (user: User) => { return user.userTypes.includes(UserType.GOD) }
-export const hasRoles = (user: User, types: UserType[]) => { return types.some(type => user.userTypes.includes(type)) }
+export const isEngineer = (user: User | UserWithCompanies) => { return user.userTypes.includes(UserType.ENGINEER) }
+export const isCompany = (user: User | UserWithCompanies) => { return user.userTypes.includes(UserType.COMPANY) }
+export const isAdmin = (user: User | UserWithCompanies) => { return user.userTypes.includes(UserType.GOD) }
+export const hasRoles = (user: User | UserWithCompanies, types: UserType[]) => { return types.some(type => user.userTypes.includes(type)) }

--- a/src/types/campaigns.ts
+++ b/src/types/campaigns.ts
@@ -1,3 +1,4 @@
 import { Prisma } from "@prisma/client";
 
 export type CampaignWithInvitations = Prisma.CampaignGetPayload<{ include: { company: true, invitations: { include: { invitee: true, invitor: true } }, } }>
+export type CampaignWithCompany = Prisma.CampaignGetPayload<{ include: { company: true, } }>


### PR DESCRIPTION
[80](https://github.com/SimonGodefroid/buggingme/issues/80)

This PR aims to:
- implement a campaign details page
- implement a minimalist dashboard for engineers and companies

|case|desktop|mobile|
|-|-|-|
|campaign details|<img width="812" alt="image" src="https://github.com/user-attachments/assets/5c2ad381-6a7a-4456-a0f3-adb9e5ca5fba">|-|
|dashboard engineer|<img width="812" alt="image" src="https://github.com/user-attachments/assets/5ffbd887-ad40-4413-a9e3-450d0f357162">|![localhost_3000_(iPhone SE)](https://github.com/user-attachments/assets/63f70cde-1c0c-49bb-b53f-05870569d211)|
|dashboard companies|<img width="812" alt="image" src="https://github.com/user-attachments/assets/6ba24d2b-ad1b-4273-a004-e89ca33ecf26">|![localhost_3000_](https://github.com/user-attachments/assets/418016ee-c478-4e6c-a284-09f353a1ce9b)|
