### PR TITLE
fix(reports): fix migration

### DIFF
--- a/prisma/migrations/20250313115559_add_notified_at_to_report/migration.sql
+++ b/prisma/migrations/20250313115559_add_notified_at_to_report/migration.sql
@@ -5,4 +5,4 @@
 
 */
 -- AlterTable
-ALTER TABLE "Report" ADD COLUMN     "notifiedAt" TIMESTAMP(3) NOT NULL;
+ALTER TABLE "Report" ADD COLUMN     "notifiedAt" TIMESTAMP(3);

--- a/prisma/migrations/20250313121847_make_notified_at_nullable/migration.sql
+++ b/prisma/migrations/20250313121847_make_notified_at_nullable/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "Report" ALTER COLUMN "notifiedAt" DROP NOT NULL;


### PR DESCRIPTION
Migration was introducing a non null attribute that is null for most records.